### PR TITLE
Update Composer dependencies (2020-04-21-00-06)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -757,16 +757,16 @@
         },
         {
             "name": "doctrine/annotations",
-            "version": "1.10.1",
+            "version": "1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "5eb79f3dbdffed6544e1fc287572c0f462bd29bb"
+                "reference": "b9d758e831c70751155c698c2f7df4665314a1cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/5eb79f3dbdffed6544e1fc287572c0f462bd29bb",
-                "reference": "5eb79f3dbdffed6544e1fc287572c0f462bd29bb",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/b9d758e831c70751155c698c2f7df4665314a1cb",
+                "reference": "b9d758e831c70751155c698c2f7df4665314a1cb",
                 "shasum": ""
             },
             "require": {
@@ -822,7 +822,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2020-04-02T12:33:25+00:00"
+            "time": "2020-04-20T09:18:32+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -4903,23 +4903,24 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.5.2",
+            "version": "6.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "43ece0e75098b7ecd8d13918293029e555a50f82"
+                "reference": "aab4ebd862aa7d04f01a4b51849d657db56d882e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/43ece0e75098b7ecd8d13918293029e555a50f82",
-                "reference": "43ece0e75098b7ecd8d13918293029e555a50f82",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/aab4ebd862aa7d04f01a4b51849d657db56d882e",
+                "reference": "aab4ebd862aa7d04f01a4b51849d657db56d882e",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "guzzlehttp/promises": "^1.0",
                 "guzzlehttp/psr7": "^1.6.1",
-                "php": ">=5.5"
+                "php": ">=5.5",
+                "symfony/polyfill-intl-idn": "^1.11"
             },
             "require-dev": {
                 "ext-curl": "*",
@@ -4927,7 +4928,6 @@
                 "psr/log": "^1.1"
             },
             "suggest": {
-                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
                 "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
@@ -4966,7 +4966,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2019-12-23T11:57:10+00:00"
+            "time": "2020-04-18T10:38:46+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -8251,16 +8251,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.7.0",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598"
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/aed98a490f9a8f78468232db345ab9cf606cf598",
-                "reference": "aed98a490f9a8f78468232db345ab9cf606cf598",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
                 "shasum": ""
             },
             "require": {
@@ -8268,7 +8268,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "vimeo/psalm": "<3.6.0"
+                "vimeo/psalm": "<3.9.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.36 || ^7.5.13"
@@ -8295,7 +8295,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-02-14T12:15:55+00:00"
+            "time": "2020-04-18T12:12:48+00:00"
         },
         {
             "name": "webmozart/path-util",


### PR DESCRIPTION
```
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 38 installs, 3 updates, 0 removals
  - Installing squizlabs/php_codesniffer (3.5.5): Downloading (connecting...)Downloading (0%)           Downloading (5%)Downloading (10%)Downloading (15%)Downloading (20%)Downloading (25%)Downloading (30%)Downloading (35%)Downloading (40%)Downloading (45%)Downloading (50%)Downloading (55%)Downloading (60%)Downloading (65%)Downloading (70%)Downloading (75%)Downloading (80%)Downloading (85%)Downloading (90%)Downloading (95%)Downloading (100%)
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.5.0): Downloading (connecting...)Downloading (0%)           Downloading (15%)Downloading (100%)
  - Updating doctrine/annotations (1.10.1 => 1.10.2): Downloading (connecting...)Downloading (100%)         
  - Installing container-interop/container-interop (1.2.0): Loading from cache
  - Installing drupal/coder (8.3.8): Cloning e53e75b458 from cache
  - Updating guzzlehttp/guzzle (6.5.2 => 6.5.3): Downloading (connecting...)Downloading (0%)           Downloading (5%)Downloading (10%)Downloading (20%)Downloading (25%)Downloading (30%)Downloading (35%)Downloading (40%)Downloading (45%)Downloading (55%)Downloading (60%)Downloading (70%)Downloading (75%)Downloading (80%)Downloading (85%)Downloading (90%)Downloading (95%)Downloading (100%)
  - Installing instaclick/php-webdriver (1.4.7): Loading from cache
  - Installing behat/mink (v1.8.1): Downloading (connecting...)Downloading (0%)           Downloading (10%)Downloading (35%)Downloading (45%)Downloading (55%)Downloading (65%)Downloading (90%)Downloading (100%)
  - Installing behat/mink-selenium2-driver (v1.4.0): Downloading (connecting...)Downloading (100%)         
  - Installing symfony/browser-kit (v4.4.7): Downloading (connecting...)Downloading (100%)         
  - Installing fabpot/goutte (v3.2.3): Loading from cache
  - Installing behat/mink-browserkit-driver (v1.3.4): Downloading (connecting...)Downloading (0%)           Downloading (10%)Downloading (100%)
  - Installing behat/mink-goutte-driver (v1.2.1): Loading from cache
  - Installing behat/transliterator (v1.3.0): Loading from cache
  - Installing behat/gherkin (v4.6.2): Downloading (connecting...)Downloading (100%)         
  - Installing behat/behat (v3.6.1): Loading from cache
  - Installing behat/mink-extension (2.3.1): Loading from cache
  - Installing drupal/drupal-extension (v3.4.1): Downloading (connecting...)Downloading (100%)         
  - Installing jcalderonzumba/gastonjs (v1.2.0): Downloading (connecting...)Downloading (100%)         
  - Installing jcalderonzumba/mink-phantomjs-driver (v0.3.3): Downloading (connecting...)Downloading (100%)         
  - Installing mikey179/vfsstream (v1.6.8): Downloading (connecting...)Downloading (0%)           Downloading (10%)Downloading (15%)Downloading (20%)Downloading (30%)Downloading (35%)Downloading (40%)Downloading (45%)Downloading (55%)Downloading (65%)Downloading (70%)Downloading (80%)Downloading (90%)Downloading (95%)Downloading (100%)
  - Installing sebastian/version (1.0.6): Downloading (connecting...)Downloading (0%)           Downloading (85%)Downloading (100%)
  - Installing sebastian/global-state (1.1.1): Downloading (connecting...)Downloading (100%)         
  - Installing sebastian/recursion-context (1.0.5): Downloading (connecting...)Downloading (100%)         
  - Installing sebastian/exporter (1.2.2): Downloading (connecting...)Downloading (100%)         
  - Installing sebastian/environment (1.3.8): Downloading (connecting...)Downloading (100%)         
  - Installing sebastian/diff (1.4.3): Downloading (connecting...)Downloading (100%)         
  - Installing sebastian/comparator (1.2.4): Downloading (connecting...)Downloading (100%)         
  - Installing doctrine/instantiator (1.3.0): Loading from cache
  - Updating webmozart/assert (1.7.0 => 1.8.0): Downloading (connecting...)Downloading (100%)         
  - Installing phpdocumentor/reflection-common (2.0.0): Loading from cache
  - Installing phpdocumentor/type-resolver (1.1.0): Downloading (connecting...)Downloading (100%)         
  - Installing phpdocumentor/reflection-docblock (5.1.0): Downloading (connecting...)Downloading (100%)         
  - Installing phpspec/prophecy (v1.10.3): Downloading (connecting...)Downloading (100%)         
  - Installing phpunit/php-text-template (1.2.1): Loading from cache
  - Installing phpunit/phpunit-mock-objects (2.3.8): Downloading (connecting...)Downloading (100%)         
  - Installing phpunit/php-timer (1.0.9): Loading from cache
  - Installing phpunit/php-token-stream (1.4.12): Downloading (connecting...)Downloading (100%)         
  - Installing phpunit/php-file-iterator (1.4.5): Loading from cache
  - Installing phpunit/php-code-coverage (2.2.4): Downloading (connecting...)Downloading (100%)         
  - Installing phpunit/phpunit (4.8.36): Downloading (connecting...)Downloading (100%)         
behat/mink suggests installing dmore/chrome-mink-driver (fast and JS-enabled driver for any app (requires chromium or google chrome))
behat/mink suggests installing behat/mink-zombie-driver (fast and JS-enabled headless driver for any app (requires node.js))
sebastian/global-state suggests installing ext-uopz (*)
phpunit/php-code-coverage suggests installing ext-xdebug (>=2.2.1)
phpunit/phpunit suggests installing phpunit/php-invoker (~1.1)
Package zendframework/zend-diactoros is abandoned, you should avoid using it. Use laminas/laminas-diactoros instead.
Package zendframework/zend-escaper is abandoned, you should avoid using it. Use laminas/laminas-escaper instead.
Package zendframework/zend-feed is abandoned, you should avoid using it. Use laminas/laminas-feed instead.
Package zendframework/zend-stdlib is abandoned, you should avoid using it. Use laminas/laminas-stdlib instead.
Package container-interop/container-interop is abandoned, you should avoid using it. Use psr/container instead.
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Writing lock file
Generating optimized autoload files
> DrupalProject\composer\ScriptHandler::createRequiredFiles
```